### PR TITLE
corrected AWS_SECRET_KEY and AWS_ACCESS_KEY to standard names 

### DIFF
--- a/lib/vagrant-s3auth/util/authenticator.rb
+++ b/lib/vagrant-s3auth/util/authenticator.rb
@@ -15,8 +15,8 @@ module VagrantPlugins
         end
 
         def initialize
-          @access_key = ENV['AWS_ACCESS_KEY_ID']
-          @secret_key = ENV['AWS_SECRET_ACCESS_KEY']
+          @access_key = ENV['AWS_ACCESS_KEY']
+          @secret_key = ENV['AWS_SECRET_KEY']
 
           ensure_credentials
         end
@@ -37,8 +37,8 @@ module VagrantPlugins
 
         def ensure_credentials
           missing_variables = []
-          missing_variables << 'AWS_ACCESS_KEY_ID' unless @access_key
-          missing_variables << 'AWS_SECRET_ACCESS_KEY' unless @secret_key
+          missing_variables << 'AWS_ACCESS_KEY' unless @access_key
+          missing_variables << 'AWS_SECRET_KEY' unless @secret_key
 
           # rubocop:disable Style/GuardClause
           unless missing_variables.empty?


### PR DESCRIPTION
Other tools like the vagrant-aws plugin and the ec2-api-tools expect the environment variables containing the secret and access key to be called AWS_SECRET_KEY and AWS_ACCESS_KEY.
