### PR TITLE
Prevent AWS namespace collision with vagrant-aws

### DIFF
--- a/lib/vagrant-s3auth/util.rb
+++ b/lib/vagrant-s3auth/util.rb
@@ -27,7 +27,7 @@ module VagrantPlugins
         end
 
         if bucket && key
-          AWS::S3.new(region: get_bucket_region(bucket))
+          ::AWS::S3.new(region: get_bucket_region(bucket))
             .buckets[bucket].objects[key]
         elsif follow_redirect
           response = Net::HTTP.get_response(url) rescue nil
@@ -45,8 +45,8 @@ module VagrantPlugins
       end
 
       def self.get_bucket_region(bucket)
-        LOCATION_TO_REGION[AWS::S3.new.buckets[bucket].location_constraint]
-      rescue AWS::S3::Errors::AccessDenied
+        LOCATION_TO_REGION[::AWS::S3.new.buckets[bucket].location_constraint]
+      rescue ::AWS::S3::Errors::AccessDenied
         raise Errors::BucketLocationAccessDeniedError,
           bucket: bucket,
           access_key: ENV['AWS_ACCESS_KEY_ID']


### PR DESCRIPTION
Running Vagrant 1.7.2 with [vagrant-aws v0.6.0](https://github.com/mitchellh/vagrant-aws/tree/v0.6.0) installed, I hit on this bug when using vagrant-s3auth v1.0.2:

```
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'stackato-v3.4.2' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
/Users/Andres_Rojas/.vagrant.d/gems/gems/vagrant-s3auth-1.0.2/lib/vagrant-s3auth/util.rb:30:in `s3_object_for': uninitialized constant VagrantPlugins::AWS::S3 (NameError)
  from /Users/Andres_Rojas/.vagrant.d/gems/gems/vagrant-s3auth-1.0.2/lib/vagrant-s3auth/extension/downloader.rb:17:in `execute_curl_with_s3'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/util/downloader.rb:169:in `head'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/box_add.rb:483:in `metadata_url?'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/box_add.rb:77:in `block in call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/box_add.rb:75:in `map'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/box_add.rb:75:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builder.rb:116:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:66:in `block in run'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/util/busy.rb:19:in `busy'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:66:in `run'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/handle_box.rb:79:in `handle_box'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/handle_box.rb:42:in `block in call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/handle_box.rb:36:in `synchronize'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/handle_box.rb:36:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builder.rb:116:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:66:in `block in run'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/util/busy.rb:19:in `busy'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:66:in `run'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/call.rb:53:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/virtualbox/action/check_virtualbox.rb:17:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
  from /Users/Andres_Rojas/.vagrant.d/gems/gems/vagrant-triggers-0.5.0/lib/vagrant-triggers/action/trigger.rb:17:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
  from /Users/Andres_Rojas/.vagrant.d/gems/gems/vagrant-triggers-0.5.0/lib/vagrant-triggers/action/trigger.rb:17:in `call'
  1 require 'aws-sdk-v1'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
  from /Users/Andres_Rojas/.vagrant.d/gems/gems/vagrant-triggers-0.5.0/lib/vagrant-triggers/action/trigger.rb:17:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builder.rb:116:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:66:in `block in run'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/util/busy.rb:19:in `busy'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:66:in `run'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/machine.rb:214:in `action_raw'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/machine.rb:191:in `block in action'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/environment.rb:516:in `lock'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/machine.rb:178:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/machine.rb:178:in `action'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/batch_action.rb:82:in `block (2 levels) in run'
```

Explicitly calling AWS from the base namespace in util.rb seems to have resolved the issue for me.