### PR TITLE
display AWS access key and source when downloading box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+**20 August 2015**
+
+Enhancements:
+
+* output the discovered AWS access key and its source (environment variable or
+  profile) when downloading an authenticated S3 box ([#21])
+
+Thanks, [@Daemoen][Daemoen]!
+
 ## 1.1.1
 
 **6 August 2015**
@@ -101,7 +112,9 @@ Enhancements:
 [#14]: https://github.com/WhoopInc/vagrant-s3auth/issues/14
 [#15]: https://github.com/WhoopInc/vagrant-s3auth/issues/15
 [#16]: https://github.com/WhoopInc/vagrant-s3auth/issues/16
+[#21]: https://github.com/WhoopInc/vagrant-s3auth/issues/21
 
+[Daemoen]: https://github.com/Daemoen
 [andres-rojas]: https://github.com/andres-rojas
 [companykitchen-dev]: https://github.com/companykitchen-dev
 [kimpepper]: https://github.com/kimpepper

--- a/lib/vagrant-s3auth/extension/downloader.rb
+++ b/lib/vagrant-s3auth/extension/downloader.rb
@@ -8,6 +8,22 @@ S3Auth = VagrantPlugins::S3Auth
 module Vagrant
   module Util
     class Downloader
+      def s3auth_credential_source
+        credential_provider = S3Auth::Util.s3_credential_provider
+        case credential_provider
+        when ::Aws::Credentials
+          I18n.t(
+            'vagrant_s3auth.downloader.env_credential_provider',
+            access_key: credential_provider.credentials.access_key_id,
+            env_var: S3Auth::Util::AWS_ACCESS_KEY_ENV_VARS.find { |k| ENV.key?(k) })
+        when ::Aws::SharedCredentials
+          I18n.t(
+            'vagrant_s3auth.downloader.profile_credential_provider',
+            access_key: credential_provider.credentials.access_key_id,
+            profile: credential_provider.profile_name)
+        end
+      end
+
       def s3auth_download(options, subprocess_options, &data_proc)
         # The URL sent to curl is always the last argument. We have to rely
         # on this implementation detail because we need to hook into both
@@ -25,6 +41,8 @@ module Vagrant
 
         @logger.info("s3auth: Generating signed URL for #{method.upcase}")
 
+        @ui.detail(s3auth_credential_source) if @ui
+
         url.replace(S3Auth::Util.s3_url_for(method, s3_object).to_s)
 
         execute_curl_without_s3auth(options, subprocess_options, &data_proc)
@@ -32,7 +50,6 @@ module Vagrant
         if e.message =~ /403 Forbidden/
           e.message << "\n\n"
           e.message << I18n.t('vagrant_s3auth.errors.box_download_forbidden',
-            access_key: ENV['AWS_ACCESS_KEY_ID'],
             bucket: s3_object && s3_object.bucket.name)
         end
         raise
@@ -45,6 +62,9 @@ module Vagrant
       def execute_curl_with_s3auth(options, subprocess_options, &data_proc)
         execute_curl_without_s3auth(options, subprocess_options, &data_proc)
       rescue Errors::DownloaderError => e
+        # Ensure the progress bar from the just-failed request is cleared.
+        @ui.clear_line if @ui
+
         s3auth_download(options, subprocess_options, &data_proc) || (raise e)
       end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,5 +1,12 @@
 en:
   vagrant_s3auth:
+    downloader:
+      env_credential_provider: |-
+        Signing S3 request with key '%{access_key}' loaded from $%{env_var}
+
+      profile_credential_provider: |-
+        Signing S3 request with key '%{access_key}' loaded from profile '%{profile}'
+
     errors:
       missing_credentials: |-
         Unable to find AWS credentials.
@@ -31,23 +38,15 @@ en:
       bucket_location_access_denied_error: |-
         Request for box's Amazon S3 region was denied.
 
-        This usually indicates that your user account with access key ID
-
-            %{access_key}
-
-        is misconfigured. Ensure your IAM policy allows the "s3:GetBucketLocation"
-        action for your bucket:
+        This usually indicates that your user account is misconfigured. Ensure
+        your IAM policy allows the "s3:GetBucketLocation" action for your bucket:
 
             arn:aws:s3:::%{bucket}
 
       box_download_forbidden: |-
         This box is hosted on Amazon S3. A 403 Forbidden error usually indicates
-        that your user account with access key ID
-
-            %{access_key}
-
-        is misconfigured. Ensure your IAM policy allows the "s3:GetObject"
-        action for your bucket:
+        that your user account is misconfigured. Ensure your IAM policy allows
+        the "s3:GetObject" action for your bucket:
 
             arn:aws:s3:::%{bucket}/*
 


### PR DESCRIPTION
Display the discovered AWS access key and its source (environment
variable or profile) when downloading an authenticated S3 box to
reduce confusion about credential source precedence.

Hopefully fix #21.